### PR TITLE
Header Compression

### DIFF
--- a/ietf-microwave-radio-link.tree
+++ b/ietf-microwave-radio-link.tree
@@ -30,7 +30,7 @@ module: ietf-microwave-radio-link
   augment /if:interfaces/if:interface:
     +--rw id?                     string
     +--rw (mode-option)
-    |  x--:(mode)
+    |  +--:(mode)
     |  |  x--rw mode              identityref
     |  +--:(rlt-mode)
     |     +--rw rlt-mode
@@ -44,8 +44,15 @@ module: ietf-microwave-radio-link
     +--rw mimo-groups*            -> /mimo-groups/mimo-group/name
     |       {mimo}?
     +--rw tdm-connections* [tdm-type] {tdm}?
-       +--rw tdm-type           identityref
-       +--rw tdm-connections    uint16
+    |  +--rw tdm-type           identityref
+    |  +--rw tdm-connections    uint16
+    +--rw header-compression {header-compression}?
+       +--ro supported-profile* [name]
+       |  +--ro name           string
+       |  +--ro description?   string
+       +--rw configured-profile?   -> ../supported-profile/name
+       +--rw enabled?              boolean
+       +--ro oper-status?          enumeration
   augment /if:interfaces/if:interface:
     +--rw carrier-id?                     string
     +--rw tx-enabled?                     boolean

--- a/ietf-microwave-radio-link.yang
+++ b/ietf-microwave-radio-link.yang
@@ -37,7 +37,8 @@ module ietf-microwave-radio-link {
       Min Ye (amy.yemin@huawei.com)
       Xi Li (Xi.Li@neclab.eu)
       Daniela Spreafico (daniela.spreafico@nokia.com)
-      Marko Vaupotic (Marko.Vaupotic@aviatnet.com)";
+      Marko Vaupotic (Marko.Vaupotic@aviatnet.com)
+      Danilo Pala (danilo.pala@siaemic.com)";
   description
     "This is a module for the entities in
      a generic microwave system.
@@ -106,6 +107,11 @@ module ietf-microwave-radio-link {
   feature tdm {
     description
       "Indicates that the device supports TDM.";
+  }
+
+  feature header-compression {
+    description
+      "Indicates that the device supports Header Compression profiles.";
   }
 
   /*
@@ -278,6 +284,61 @@ module ietf-microwave-radio-link {
         mandatory true;
         description
           "Number of connections of the specified type.";
+      }
+    }
+    container header-compression {
+      if-feature "header-compression";
+      description
+        "Configuration of Header Compression ";
+      list supported-profile {
+        key "name";
+        config false;
+        description
+          "The list of header compression profiles supported by the RLT.
+
+           Header compression is typically vendor proprietary and it is
+           assumed there is no ambition to change that. For this reason
+           the list provides only generic attributes to be augmented by
+           vendor with proprietary implementation attributes.";
+        leaf name {
+          type string;
+          description
+            "A name that uniquely identifies the header compression profile
+             in an RLT.";
+        }
+        leaf description {
+          type string;
+          description
+            "Detailed description of the profile.";
+        }
+      }
+      leaf configured-profile {
+        type leafref {
+          path "../mrl:supported-profile/mrl:name";
+          require-instance false;
+        }
+        description
+          "Select the profile of header compression to be used.";
+      }
+      leaf enabled {
+        type boolean;
+        description
+          "Disables (false) or enables (true) the header compression.";
+      }
+      leaf oper-status {
+        type enumeration {
+          enum off {
+            description
+              "Header compression is off.";
+          }
+          enum on {
+            description
+              "Header compression is on.";
+          }
+        }
+        config false;
+        description
+          "Shows the operative status of the header compression.";
       }
     }
   }
@@ -808,11 +869,10 @@ module ietf-microwave-radio-link {
           }
           leaf profile-channel-separation-id-ref {
             type leafref {
-              path
-                "../../.."
-              + "/acm-profile-list[profile-coding-modulation-id="
-              + "current()/../profile-coding-modulation-id-ref]"
-              + "/profile-channel-separation-id";
+              path "../../.."
+                 + "/acm-profile-list[profile-coding-modulation-id="
+                 + "current()/../profile-coding-modulation-id-ref]"
+                 + "/profile-channel-separation-id";
             }
             description
               "A reference to an acm-profile to give an order in
@@ -845,11 +905,10 @@ module ietf-microwave-radio-link {
           }
           leaf profile-channel-separation-id-ref {
             type leafref {
-              path
-                "../../.."
-              + "/acm-profile-list[profile-coding-modulation-id="
-              + "current()/../profile-coding-modulation-id-ref]"
-              + "/profile-channel-separation-id";
+              path "../../.."
+                 + "/acm-profile-list[profile-coding-modulation-id="
+                 + "current()/../profile-coding-modulation-id-ref]"
+                 + "/profile-channel-separation-id";
             }
             description
               "A reference to an acm-profile to give an order in

--- a/ietf-microwave-types.yang
+++ b/ietf-microwave-types.yang
@@ -13,7 +13,8 @@ module ietf-microwave-types {
       Min Ye (amy.yemin@huawei.com)
       Xi Li (Xi.Li@neclab.eu)
       Daniela Spreafico (daniela.spreafico@nokia.com)
-      Marko Vaupotic (Marko.Vaupotic@aviatnet.com)";
+      Marko Vaupotic (Marko.Vaupotic@aviatnet.com)
+      Danilo Pala (danilo.pala@siaemic.com)";
   description
     "This module contains a collection of YANG data types
      considered generally useful for microwave interfaces.


### PR DESCRIPTION
Fix #32

Added parameters (for RLT) in the yang file to handle header compression, just as an example to be reviewed.

A boolean attribute has been added just to activate/deactivate the functionality.

    +--rw header-compression-enabled?        boolean

For devices that require more complex configuration, a list of profiles has been added, each composed of a list of protocol headers to compress or composed of the size of the area at the beginning of the packet where all included headers are compressed.

 ```
   +--ro header-compression-profile-list* [header-compression-profile-name] {hc-profile}?
    |  +--ro header-compression-profile-name         string
    |  +--ro (header-compression)?
    |     +--:(protocol-based)
    |     |  +--ro compressed-protocol-layer-list*   mw-types:protocol-layer
    |     |  +--ro mpls-payload-kind-list*           mw-types:mpls-payload
    |     +--:(header-length-based)
    |        +--ro compressed-header-length?         int16

```
A configuration attribute selects the profile to use.

`      +--rw header-compression-profile?        -> ../header-compression-profile-list/header-compression-profile-name {hc-profile}?
`
(not sure if the path is correct)

A feature hc-profile has been added to include or exclude the header compression profile support.

```
  feature hc-profile {
    description
      "Indicates that the device supports Header Compression profiles.";
  }
```

Unlike from modules inside the zip file uploaded in [issue#32](https://github.com/samans/draft-ybam-rfc8561bis/issues/32) the added code is NOT wrapped inside the couple of markers:

